### PR TITLE
expose lib.writeZxApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ a simple wrapper to be able to run [zx](https://github.com/google/zx) scripts.
 
 ## Using
 
+_for users who don't want to use an overlay, this flake exposes `lib.writeZxApplication`, used like `inputs.${system}.lib.writeZxApplication` with the same API as the function the overlay exposes._
+
 first, add it as an overlay:
 
 ```nix

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
 
     overlays.nixzx = self.overlays.default;
 
+    lib.${system}.writeZxApplication = import ./nixzx.nix (import nixpkgs {inherit system;});
+
     checks.${system} = let
       pkgs = import nixpkgs {
         inherit system;


### PR DESCRIPTION
there's no cannonical way to expose a function so lib is good enough.